### PR TITLE
Use url as string

### DIFF
--- a/packages/vue-pdf-editor/src/VuePdfEditor.vue
+++ b/packages/vue-pdf-editor/src/VuePdfEditor.vue
@@ -368,9 +368,7 @@ export default {
 				return
 			}
 			try {
-				const res = await fetch(this.initFileSrc)
-				const pdfBlob = await res.blob()
-				await this.addPDF(pdfBlob)
+				await this.addPDF(this.initFileSrc)
 				this.selectedPageIndex = 0
 				fetchFont(this.currentFont)
 				this.narrowEnlargeShow = true
@@ -485,10 +483,15 @@ export default {
 				this.pdfFile = file
 				if (this.initFileName) {
 					this.pdfName = this.initFileName
-				} else if (file.name) {
+				} else if (file instanceof File && file.name) {
 					this.pdfName = file.name
 				} else {
 					this.pdfName = new Date().getTime()
+				}
+
+				if (file instanceof File) {
+					const blob = new Blob([file])
+					file = await blob.arrayBuffer();
 				}
 
 				this.pdfDocument = await readAsPDF(file)

--- a/packages/vue-pdf-editor/utils/asyncReader.js
+++ b/packages/vue-pdf-editor/utils/asyncReader.js
@@ -53,7 +53,5 @@ export async function readAsPDF(file) {
 	const pdfjsLib = require('pdfjs-dist')
 	const pdfjsWorker = require('pdfjs-dist/build/pdf.worker.entry')
 	pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker
-	const blob = new Blob([file])
-	const url = window.URL.createObjectURL(blob)
-	return pdfjsLib.getDocument(url).promise
+	return pdfjsLib.getDocument(file).promise
 }


### PR DESCRIPTION
The PDF.js can use URL as string and other types of PDF file to load the document. I maintained as string to don't have problems with cors