### PR TITLE
Expose src folder at package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@
 examples/
 node_modules/
 public/
-src/
 .editorconfig
 .eslintignore
 .gitignore


### PR DESCRIPTION
When we pack this package to send to npmjs, the .npmignore file contains the list that need (or not) to go to package. I got a case that I need the .vue file in package to be used.